### PR TITLE
Update README.md to include instructions of building multi-arch JARs.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,22 +206,7 @@ C5.4XL	                        M6g.4XL
 ```
 
 ## Java
-For languages that rely on a JIT (such an Java), the symbol information that is
-captured is lacking, making it difficult to understand where runtime is being consumed.
-Similar to the code profiling example above, `libperf-jvmti.so` can be used to dump symbols for
-JITed code as the JVM runs.
 
-```bash
-# find where libperf-jvmti.so is, on Ubuntu ... AL2 ...
-
-# Run your java app with -agentpath:/path/to/libperf-jvmti.so added to the command line
-
-# Inject the generated methods information into the perf.data file
-$ perf inject -i perf.data -j /path/to/jit.dump -o perf.data.jit
-
-# Process the new file
-$ perf script -i perf.data.jit | ./FlameGraph/stackcollapse-perf.pl | ./FlameGraph/flamegraph.pl > ./flamegraph.svg
-```
 ### Looking for x86 shared-objects in JARs
 Java JARs can include shared-objects that are architecture specific. Some Java libraries check
 if these shared objects are found and if they are they use a JNI to call to the native library
@@ -242,7 +227,83 @@ consult our [Common JARs with native code Table](CommonNativeJarsTable.md).
 Feel free to open an issue in this GitHub repo or contact us at ec2-arm-dev-feedback@amazon.com
 for advice on getting Arm support for a required Jar. 
 
+### Building multi-arch JARs
+Java is meant to be a write once, and run anywhere language.  When building Java artifacts that
+contain native code, it is important to build those libraries for each major architecture to provide
+a seamless and optimally performing experience for all consumers.  Code that runs well on both Graviton and x86
+based instances increases the package's utility.
 
+There is nominally a multi-step process to build the native shared objects for each supported
+architecture before doing the final packaging with Maven, SBT, Gradle etc. Below is an example
+of how to create your JAR using Maven that contains shared libraries for multiple distributions
+and architectures for running your Java application interchangeably on AWS EC2 instances
+based on x86 and Graviton processors:
+
+```
+# Create two build instances, one x86 and one Graviton instance.
+# Pick on instance to be the primary instance.
+# Log into the secondary instance
+$ cd java-lib
+$ mvn package
+$ find target/ -name "*.so" -type f -print
+
+# Note the directory this so file is in, it will be in a directory
+# such as: target/classes/org/your/class/hierarchy/native/OS/ARCH/lib.so
+
+# Log into the primary build instance
+$ cd java-lib
+$ mvn package
+
+# Repeat the below two steps for each OS and ARCH combination you want to release
+$ mkdir target/classes/org/your/class/hierarchy/native/OS/ARCH
+$ scp slave:~/your-java-lib/target/classes/org/your/class/hierarchy/native/OS/ARCH/lib.so target/classes/org/your/class/hierarchy/native/OS/ARCH/
+
+# Create the jar packaging with maven.  It will include the additional
+# native libraries even though they were not built directly by this maven process.
+$ mvn package
+
+# When creating a single Jar for all platform native libraries, 
+# the release plugin's configuration must be modified to specify 
+# the plugin's `preparationGoals` to not include the clean goal.
+# See http://maven.apache.org/maven-release/maven-release-plugin/prepare-mojo.html#preparationGoals
+# For more details.
+
+# To do a release to Maven Central and/or Sonatype Nexus:
+$ mvn release:prepare
+$ mvn release:perform
+
+```
+
+This is one way to do the JAR packaging with all the libraries in a single JAR.  To build all the JARs, we recommend to build on native
+machines, but it can also be done via Docker using the buildx plug-in, or by cross-compiling inside your build-environment.
+
+Additional options for releasing jars with native code is to: use a manager plugin such as the [nar maven plugin](https://maven-nar.github.io/)
+to manage each platform specific Jar.  Release individual architecture specific jars, and then use the primary
+instance to download these released jars and package them into a combined Jar with a final `mvn release:perform`.
+An example of this methd can be found in the [Leveldbjni-native](https://github.com/fusesource/leveldbjni) `pom.xml` files. 
+
+
+### Profiling Java applications
+For languages that rely on a JIT (such an Java), the symbol information that is
+captured is lacking, making it difficult to understand where runtime is being consumed.
+Similar to the code profiling example above, `libperf-jvmti.so` can be used to dump symbols for
+JITed code as the JVM runs.
+
+```bash
+# Compile your Java application with -g
+
+# find where libperf-jvmti.so is on your distribution
+
+# Run your java app with -agentpath:/path/to/libperf-jvmti.so added to the command line
+# Launch perf record on the system
+$ perf record -g -k 1 -a -o perf.data sleep 5
+
+# Inject the generated methods information into the perf.data file
+$ perf inject -j -i perf.data -o perf.data.jit
+
+# Process the new file, for instance via Brendan Gregg's Flamegraph tools
+$ perf script -i perf.data.jit | ./FlameGraph/stackcollapse-perf.pl | ./FlameGraph/flamegraph.pl > ./flamegraph.svg
+```
 
 # Resources
 


### PR DESCRIPTION
Update README.md Java section instructions with revised profiling instructions and how to build multi-arch JARs for those who are developing on both x86 and Graviton.