### PR TITLE
Update Jars table with version numbers for artifacts

### DIFF
--- a/CommonNativeJarsTable.md
+++ b/CommonNativeJarsTable.md
@@ -1,19 +1,19 @@
 ## Commonly used Jars that package native artifacts
 
-Org  | jar  | Builds on Arm | Arm Artifact available
------|------|---------------|--------------------
-com.github.luben | [zstd-jni](https://github.com/luben/zstd-jni) | yes | [yes](https://mvnrepository.com/artifact/com.github.luben/zstd-jni)
-org.lz4 | [lz4-java](https://github.com/lz4/lz4-java) | yes | [yes](https://mvnrepository.com/artifact/org.lz4/lz4-java)
-org.xerial.snappy | [snappy-java](https://github.com/xerial/snappy-java) | yes | [yes](https://mvnrepository.com/artifact/org.xerial.snappy/snappy-java)
-org.rocksdb | [rocksdbjni](https://github.com/facebook/rocksdb/tree/master/java) | yes | [yes](https://mvnrepository.com/artifact/org.rocksdb/rocksdbjni)
-com.github.jnr | [jffi](https://github.com/jnr/jffi) | yes | [yes](https://mvnrepository.com/artifact/com.github.jnr/jffi)
-org.apache.commons | [commons-crypto](https://github.com/apache/commons-crypto) | yes | no
-io.netty | [netty-transport-native-epoll](https://github.com/netty/netty) | yes | [yes](https://mvnrepository.com/artifact/io.netty/netty-transport-native-epoll)
-io.netty | [netty-tcnative](https://github.com/netty/netty-tcnative) | yes | no
-org.fusesource.jansi | [jansi-native](https://github.com/fusesource/jansi-native) | yes | no
-org.fusesource.leveldbjni | [leveldbjni-all](https://github.com/fusesource/leveldbjni) | no | no
-org.fusesource.sigar | [sigar](https://github.com/hyperic/sigar) | no | no
-org.apache.hadoop | [hadoop-lzo](https://github.com/twitter/hadoop-lzo) | no | no
+Org  | jar  | Builds on Arm | Arm Artifact available | Minimum Version
+-----|------|---------------|------------------------|---------
+com.github.luben | [zstd-jni](https://github.com/luben/zstd-jni) | yes | [yes](https://mvnrepository.com/artifact/com.github.luben/zstd-jni) | 1.2.0
+org.lz4 | [lz4-java](https://github.com/lz4/lz4-java) | yes | [yes](https://mvnrepository.com/artifact/org.lz4/lz4-java) | 1.4.0
+org.xerial.snappy | [snappy-java](https://github.com/xerial/snappy-java) | yes | [yes](https://mvnrepository.com/artifact/org.xerial.snappy/snappy-java) | 1.1.4
+org.rocksdb | [rocksdbjni](https://github.com/facebook/rocksdb/tree/master/java) | yes | [yes](https://mvnrepository.com/artifact/org.rocksdb/rocksdbjni) | 5.0.1
+com.github.jnr | [jffi](https://github.com/jnr/jffi) | yes | [yes](https://mvnrepository.com/artifact/com.github.jnr/jffi) | 1.2.13
+org.apache.commons | [commons-crypto](https://github.com/apache/commons-crypto) | yes | no |
+io.netty | [netty-transport-native-epoll](https://github.com/netty/netty) | yes | [yes](https://mvnrepository.com/artifact/io.netty/netty-transport-native-epoll) | 4.1.50
+io.netty | [netty-tcnative](https://github.com/netty/netty-tcnative) | yes | [yes](https://mvnrepository.com/artifact/io.netty/netty-tcnative) | 2.0.31
+org.fusesource.jansi | [jansi-native](https://github.com/fusesource/jansi-native) | yes | no |
+org.fusesource.leveldbjni | [leveldbjni-all](https://github.com/fusesource/leveldbjni) | no | no |
+org.fusesource.sigar | [sigar](https://github.com/hyperic/sigar) | no | no |
+org.apache.hadoop | [hadoop-lzo](https://github.com/twitter/hadoop-lzo) | no | no |
 
 ---
-Updated on 2020-05-04
+Updated on 2020-06-16


### PR DESCRIPTION
Update the CommonNativeJarsTable.md with new information as of 16-06-2020.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
